### PR TITLE
fix: move mini calendar initialization from HTML to JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,6 @@
     <link rel="icon" href="/favicon/favicon-dark.ico" media="(prefers-color-scheme: dark)" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dootzy</title>
-    <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.17/index.global.min.js'></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        var calendarEl = document.getElementById('calendar');
-        var calendar = new FullCalendar.Calendar(calendarEl, {
-          initialView: 'dayGridMonth'
-        });
-        calendar.render();
-      });
-    </script>
   </head>
   <body>
     <script type="module" src="/src/main.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fullcalendar/core": "^6.1.17",
+        "@fullcalendar/daygrid": "^6.1.17",
         "fullcalendar": "^6.1.17"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@fullcalendar/core": "^6.1.17",
+    "@fullcalendar/daygrid": "^6.1.17",
     "fullcalendar": "^6.1.17"
   }
 }

--- a/src/components/DailyPanel/DailyPanel.css
+++ b/src/components/DailyPanel/DailyPanel.css
@@ -13,7 +13,7 @@
     margin-bottom: 20px;
 }
 
-.fc-button {
+#mini-calendar .fc-button {
     background-color: #3a716a !important;
     color: rgba(255, 255, 255, 0.87) !important;
     border: none !important;
@@ -22,48 +22,48 @@
 }
 
 /* Hover y focus */
-.fc-button:hover, .fc-button:focus {
+#mini-calendar .fc-button:hover, #mini-calendar .fc-button:focus {
     background-color: #2e5751 !important; /* tono más oscuro */
     outline: none !important;
 }
 
 /* Botón activo (por ejemplo, el botón seleccionado) */
-.fc-button.fc-button-active {
+#mini-calendar .fc-button.fc-button-active {
     background-color: #266052 !important;
     box-shadow: 0 0 5px rgba(38, 96, 82, 0.7) !important;
 }
 
 /* Botones de meses */
-.fc-button {
+#mini-calendar .fc-button {
     background-color: #3a716a !important;
     color: rgba(255, 255, 255, 0.87) !important;
     transition: background-color 0.3s ease;
     border: 1px solid #2e5751 !important;
 }
 
-.fc-button:hover, .fc-button:focus {
+#mini-calendar .fc-button:hover, #mini-calendar .fc-button:focus {
     background-color: #2e5751 !important;
 }
 
 /* Botón activo */
-.fc-button.fc-button-active {
+#mini-calendar .fc-button.fc-button-active {
     background-color: #266052 !important;
 }
 
-.fc-today-button {
+#mini-calendar .fc-today-button {
     background-color: #3a716a !important;
     color: rgba(255, 255, 255, 0.87) !important;
     font-weight: bold !important;
 }
 
-.fc-today-button:hover, .fc-today-button:focus {
+#mini-calendar .fc-today-button:hover,#mini-calendar .fc-today-button:focus {
     background-color: #2e5751 !important;
 }
 
 /* Grid */
-.fc-daygrid {
+#mini-calendar .fc-daygrid {
     border-radius: 12px;
-    overflow: hidden; /* para que no se salga nada */
+    overflow: hidden;
     background-color: var(--text);
     color: var(--background);
 }
@@ -74,7 +74,7 @@
 }
 
 /* Casilla de un día */
-.fc-daygrid-day-frame {
+#mini-calendar .fc-daygrid-day-frame {
     display: flex;
     flex-direction: column;
     align-items: start;
@@ -82,11 +82,11 @@
 }
 
 /* Número del día */
-.fc-daygrid-day-number {
+#mini-calendar .fc-daygrid-day-number {
     font-weight: bold;
 }
 
 /* Día de hoy */
-.fc-day-today {
+#mini-calendar .fc-day-today {
     background-color: rgba(103, 198, 187, 0.5) !important;;
 }

--- a/src/components/DailyPanel/DailyPanel.js
+++ b/src/components/DailyPanel/DailyPanel.js
@@ -1,6 +1,6 @@
 import "./DailyPanel.css";
-import { Weather } from "../Weather/Weather.js"; 
-import esLocale from "@fullcalendar/core/locales/es";
+import { Weather } from "../Weather/Weather.js";
+import { initMiniCalendar } from "../FullCalendar/FullCalendar.js";
 
 export const DailyPanel = () => {
   const aside = document.createElement("aside");
@@ -11,19 +11,12 @@ export const DailyPanel = () => {
     </div>
     <div class="container-weather"></div>
   `;
- Weather();
+  Weather();
 
-  // Inicializa el calendario cuando el aside ya está listo
   setTimeout(() => {
-    const calendarEl = aside.querySelector("#mini-calendar");
-    if (calendarEl) {
-      const calendar = new FullCalendar.Calendar(calendarEl, {
-        initialView: "dayGridMonth",
-        locale: esLocale
-      });
-      calendar.render();
-    }
+    initMiniCalendar("#mini-calendar");
   }, 0);
+  
 
   return aside;
 };

--- a/src/components/FullCalendar/FullCalendar.js
+++ b/src/components/FullCalendar/FullCalendar.js
@@ -2,6 +2,7 @@ import { Calendar } from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import interactionPlugin from "@fullcalendar/interaction";
+import esLocale from "@fullcalendar/core/locales/es";
 
 export const initCalendar = (selector) => {
     const calendarEl = document.querySelector(selector);
@@ -42,3 +43,15 @@ export const initCalendar = (selector) => {
 
     calendar.render();
 };
+
+export const initMiniCalendar = (selector) => {
+    const calendarEl = document.querySelector(selector);
+
+    const calendar = new Calendar(calendarEl, {
+        plugins: [dayGridPlugin],
+        initialView: "dayGridMonth",
+        locale: esLocale
+    });
+
+    calendar.render();
+}

--- a/src/pages/Calendar/Calendar.css
+++ b/src/pages/Calendar/Calendar.css
@@ -1,8 +1,23 @@
 #my-calendar{
     height: fit-content;
-
 }
 
-/* #calendar.fc{
-    height: 100%;
-} */
+#my-calendar .fc .fc-toolbar-title {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  font-size: 1.8rem;
+}
+
+#my-calendar .fc-button {
+  background-color: #6f42c1;
+  border: none;
+  border-radius: 5px;
+  color: white;
+  padding: 6px 12px;
+  font-weight: 600;
+  transition: background-color 0.3s ease;
+}
+
+#my-calendar .fc-button:hover {
+  background-color: #563d7c;
+}

--- a/src/pages/Calendar/Calendar.js
+++ b/src/pages/Calendar/Calendar.js
@@ -11,15 +11,9 @@ export const MyCalendar = () => {
 
     myCalendar.appendChild(calendar);
 
-
-    
-
     setTimeout(() => {
         initCalendar("#calendar");
     }, 0);
     
-    
-    
-
     return myCalendar;
 };


### PR DESCRIPTION
La inicialización del mini calendario estaba en un script dentro del HTML, lo que causaba problemas de renderizado y estilos.  Ahora se ha movido al archivo JS para asegurar una carga correcta con estilos y funcionalidad.